### PR TITLE
Order processing fixes

### DIFF
--- a/src/main/scala/com/example/model/OrderRow.scala
+++ b/src/main/scala/com/example/model/OrderRow.scala
@@ -3,7 +3,7 @@ package com.example.model
 import java.time.Instant
 
 case class OrderRow(
-  orderId: String,
+  orderId: OrderId,
   market: String,
   total: BigDecimal,
   filled: BigDecimal, //state of completion of the order

--- a/src/main/scala/com/example/model/TransactionRow.scala
+++ b/src/main/scala/com/example/model/TransactionRow.scala
@@ -16,7 +16,7 @@ object TransactionRow {
     TransactionRow(
       id = UUID.randomUUID(), // generate some id for our transaction
       orderId = state.orderId,
-      amount = state.filled,
+      amount = updated.filled - state.filled,
       createdAt = Instant.now()
     )
   }

--- a/src/main/scala/com/example/model/TransactionRow.scala
+++ b/src/main/scala/com/example/model/TransactionRow.scala
@@ -13,11 +13,16 @@ case class TransactionRow(
 object TransactionRow {
 
   def apply(state: OrderRow, updated: OrderRow): TransactionRow = {
+//    val amount = Math.max(updated.filled.toDouble, state.filled.toDouble) -
+//      Math.min(updated.filled.toDouble, state.filled.toDouble)
+    val amount = updated.filled - state.filled
+    println(amount)
+
     TransactionRow(
       id = UUID.randomUUID(), // generate some id for our transaction
       orderId = state.orderId,
       // should be validated in an FSM; theoretically each next update should have bigger value for filled
-      amount = updated.filled - state.filled,
+      amount = amount,
       createdAt = Instant.now()
     )
   }

--- a/src/main/scala/com/example/model/TransactionRow.scala
+++ b/src/main/scala/com/example/model/TransactionRow.scala
@@ -16,6 +16,7 @@ object TransactionRow {
     TransactionRow(
       id = UUID.randomUUID(), // generate some id for our transaction
       orderId = state.orderId,
+      // should be validated in an FSM; theoretically each next update should have bigger value for filled
       amount = updated.filled - state.filled,
       createdAt = Instant.now()
     )

--- a/src/main/scala/com/example/model/TransactionRow.scala
+++ b/src/main/scala/com/example/model/TransactionRow.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 
 case class TransactionRow(
   id: UUID,
-  orderId: String, // the same as OrderRow
+  orderId: OrderId, // the same as OrderRow
   amount: BigDecimal,
   createdAt: Instant
 )

--- a/src/main/scala/com/example/model/TransactionRow.scala
+++ b/src/main/scala/com/example/model/TransactionRow.scala
@@ -13,17 +13,14 @@ case class TransactionRow(
 object TransactionRow {
 
   def apply(state: OrderRow, updated: OrderRow): TransactionRow = {
-//    val amount = Math.max(updated.filled.toDouble, state.filled.toDouble) -
-//      Math.min(updated.filled.toDouble, state.filled.toDouble)
     val amount = updated.filled - state.filled
-    println(amount)
 
     TransactionRow(
       id = UUID.randomUUID(), // generate some id for our transaction
       orderId = state.orderId,
       // should be validated in an FSM; theoretically each next update should have bigger value for filled
       amount = amount,
-      createdAt = Instant.now()
+      createdAt = Instant.now
     )
   }
 }

--- a/src/main/scala/com/example/model/package.scala
+++ b/src/main/scala/com/example/model/package.scala
@@ -1,0 +1,7 @@
+package com.example
+
+package object model {
+
+  type OrderId = String // todo: define proper type
+
+}

--- a/src/main/scala/com/example/stream/OrderFsm.scala
+++ b/src/main/scala/com/example/stream/OrderFsm.scala
@@ -1,0 +1,15 @@
+package com.example.stream
+
+import cats.implicits.catsSyntaxOptionId
+import cats.syntax.all.none
+import com.example.model.{OrderRow, TransactionRow}
+
+object OrderFsm {
+
+  def ifPositive(order: OrderRow): Option[OrderRow] =
+    if (order.filled > 0) order.some else none
+
+  // todo: check negative amounts
+  def toTransaction(existing: OrderRow, updated: OrderRow): Option[TransactionRow] =
+    if (existing.filled != existing.total) TransactionRow(existing, updated).some else none
+}

--- a/src/main/scala/com/example/stream/OrderFsm.scala
+++ b/src/main/scala/com/example/stream/OrderFsm.scala
@@ -10,17 +10,10 @@ object OrderFsm {
   case object SmallerOrder extends OrderProcessingResult
   case class ProcessOrder(order: OrderRow, txn: TransactionRow) extends OrderProcessingResult
 
-  def check(existing: OrderRow, incoming: OrderRow): OrderProcessingResult = {
-    println(s"${existing.filled} -> ${incoming.filled}")
-    if (existing.filled == existing.total)
-      FilledOrder
-    else if (incoming.filled <= 0)
-      NonPositiveOrder
-    else if (existing.filled > incoming.filled)
-      SmallerOrder
-    else {
-      ProcessOrder(incoming, TransactionRow(existing, incoming))
-    }
-  }
+  def check(existing: OrderRow, incoming: OrderRow): OrderProcessingResult =
+    if (existing.filled == existing.total) FilledOrder
+    else if (incoming.filled <= 0) NonPositiveOrder
+    else if (existing.filled > incoming.filled) SmallerOrder
+    else ProcessOrder(incoming, TransactionRow(existing, incoming))
 
 }

--- a/src/main/scala/com/example/stream/OrderFsm.scala
+++ b/src/main/scala/com/example/stream/OrderFsm.scala
@@ -10,10 +10,17 @@ object OrderFsm {
   case object SmallerOrder extends OrderProcessingResult
   case class ProcessOrder(order: OrderRow, txn: TransactionRow) extends OrderProcessingResult
 
-  def check(existing: OrderRow, incoming: OrderRow): OrderProcessingResult =
-    if (existing.filled == existing.total) FilledOrder
-    else if (incoming.filled <= 0) NonPositiveOrder
-    else if (existing.filled > incoming.filled) SmallerOrder
-    else ProcessOrder(incoming, TransactionRow(existing, incoming))
+  def check(existing: OrderRow, incoming: OrderRow): OrderProcessingResult = {
+    println(s"${existing.filled} -> ${incoming.filled}")
+    if (existing.filled == existing.total)
+      FilledOrder
+    else if (incoming.filled <= 0)
+      NonPositiveOrder
+    else if (existing.filled > incoming.filled)
+      SmallerOrder
+    else {
+      ProcessOrder(incoming, TransactionRow(existing, incoming))
+    }
+  }
 
 }

--- a/src/main/scala/com/example/stream/OrderProcessor.scala
+++ b/src/main/scala/com/example/stream/OrderProcessor.scala
@@ -41,7 +41,7 @@ object OrderProcessor {
   ): OrderProcessor[F] = new OrderProcessor[F] {
 
     override def process(stream: Stream[F, OrderRow], f: OrderRow => F[Unit]): Stream[F, Unit] =
-      stream.parEvalMap(maxConcurrent)(withRef(f))
+      stream.parEvalMapUnordered(maxConcurrent)(withRef(f))
 
     private def withRef(f: OrderRow => F[Unit])(order: OrderRow): F[Unit] =
       for {

--- a/src/main/scala/com/example/stream/OrderProcessor.scala
+++ b/src/main/scala/com/example/stream/OrderProcessor.scala
@@ -1,0 +1,68 @@
+package com.example.stream
+
+import cats.syntax.all._
+import cats.effect.std.MapRef
+import cats.effect.{Async, Concurrent, Deferred}
+import cats.implicits.toFunctorOps
+import com.example.model.{OrderId, OrderRow}
+import fs2.Stream
+
+trait OrderProcessor[F[_]] {
+  def process(
+      s: Stream[F, OrderRow],
+      f: OrderRow => F[Unit]
+  ): Stream[F, Unit]
+  // if needed, can be generalized into def process[T, R](
+  //      s: Stream[F, T],
+  //      f: T => F[R]
+  //  ): Stream[F, R]... which is basically a Pipe
+}
+
+object OrderProcessor {
+
+  sealed trait ProcessingStrategy
+  object ProcessingStrategy {
+    case object Sequential extends ProcessingStrategy
+    case class Concurrent(maxConcurrent: Int) extends ProcessingStrategy
+    object Concurrent {
+      val Default: Concurrent = Concurrent(10)
+    }
+    val Default: ProcessingStrategy = Concurrent.Default
+  }
+
+  private def sequential[F[_]]: OrderProcessor[F] = new OrderProcessor[F] {
+    override def process(stream: Stream[F, OrderRow], f: OrderRow => F[Unit]): Stream[F, Unit] =
+      stream.evalMap(f)
+  }
+
+  private def concurrent[F[_]: Concurrent](
+      maxConcurrent: Int,
+      mapRef: MapRef[F, OrderId, Option[Deferred[F, Unit]]]
+  ): OrderProcessor[F] = new OrderProcessor[F] {
+
+    private def withRef(f: OrderRow => F[Unit])(order: OrderRow): F[Unit] =
+      for {
+        maybeLock <- mapRef(order.orderId).get
+        _ <- maybeLock.traverse_(_.get)
+        newLock <- Deferred[F, Unit]
+        _ <- mapRef.setKeyValue(order.orderId, newLock)
+        _ <- f(order)
+        _ <- newLock.complete(())
+        _ <- mapRef.unsetKey(order.orderId)
+      } yield ()
+
+    override def process(stream: Stream[F, OrderRow], f: OrderRow => F[Unit]): Stream[F, Unit] =
+      stream.parEvalMapUnordered(maxConcurrent)(withRef(f))
+  }
+
+  private def concurrentOf[F[_]: Async](maxConcurrent: Int): F[OrderProcessor[F]] =
+    MapRef.ofConcurrentHashMap[F, String, Deferred[F, Unit]]().map { ref =>
+      concurrent[F](maxConcurrent, ref)
+    }
+
+  def of[F[_]: Async](ps: ProcessingStrategy): F[OrderProcessor[F]] = ps match {
+    case ProcessingStrategy.Sequential      => sequential[F].pure[F]
+    case ProcessingStrategy.Concurrent(max) => concurrentOf[F](max)
+  }
+
+}

--- a/src/main/scala/com/example/stream/OrderProcessor.scala
+++ b/src/main/scala/com/example/stream/OrderProcessor.scala
@@ -41,7 +41,7 @@ object OrderProcessor {
   ): OrderProcessor[F] = new OrderProcessor[F] {
 
     override def process(stream: Stream[F, OrderRow], f: OrderRow => F[Unit]): Stream[F, Unit] =
-      stream.parEvalMapUnordered(maxConcurrent)(withRef(f))
+      stream.parEvalMap(maxConcurrent)(withRef(f))
 
     private def withRef(f: OrderRow => F[Unit])(order: OrderRow): F[Unit] =
       for {

--- a/src/main/scala/com/example/stream/StateManager.scala
+++ b/src/main/scala/com/example/stream/StateManager.scala
@@ -1,18 +1,36 @@
 package com.example.stream
 
-import cats.effect.Async
-import com.example.model.OrderRow
+import cats.effect.implicits.{genSpawnOps, genTemporalOps_}
+import cats.effect.{Async, Deferred}
+import com.example.model.{OrderId, OrderRow}
 import com.example.persistence.PreparedQueries
 import skunk.PreparedCommand
 import cats.syntax.all._
 import fs2.concurrent.SignallingRef
 
+import scala.concurrent.duration.DurationInt
+
 //Utility for managing placed order state
 //This can be used by other components, for example a stream that performs order placement will use add method
 final class StateManager[F[_]: Async](ioSwitch: SignallingRef[F, Boolean]) {
 
-  def getOrderState(order: OrderRow, queries: PreparedQueries[F]): F[OrderRow] = {
-    queries.getOrder.unique(order.orderId)
+  def getOrderState(orderId: OrderId, queries: PreparedQueries[F]): F[OrderRow] = {
+    def retryUntilFound(deferred: Deferred[F, OrderRow]): F[Unit] = {
+      val attemptGet = queries.getOrder.unique(orderId).attempt
+
+      def loop: F[Unit] = attemptGet.flatMap {
+        case Right(order) => deferred.complete(order).void
+        case Left(_) => loop
+      }
+
+      loop
+    }
+
+    for {
+      deferred <- Deferred[F, OrderRow]
+      _ <- retryUntilFound(deferred).start // unsafe?
+      result <- deferred.get.timeoutTo(5.seconds, new Exception(s"No order found for id $orderId").raiseError) // todo: add custom errors
+    } yield result
   }
 
   def add(row: OrderRow, insert: PreparedCommand[F, OrderRow]): F[Unit] = {

--- a/src/main/scala/com/example/stream/StreamOps.scala
+++ b/src/main/scala/com/example/stream/StreamOps.scala
@@ -1,0 +1,32 @@
+package com.example.stream
+
+import cats.effect.{Concurrent, Ref}
+import cats.effect.std.Queue
+import fs2.{Pipe, Stream}
+import cats.implicits._
+
+private[stream] object StreamOps {
+
+  def groupBy[F[_]: Concurrent, A, K](
+      selector: A => F[K]
+  ): Pipe[F, A, (K, Stream[F, A])] = in =>
+    Stream.eval(Ref.of[F, Map[K, Queue[F, Option[A]]]](Map.empty)).flatMap { queueMap =>
+      val cleanup = queueMap.get.flatMap(_.values.toList.traverse_(_.offer(None)))
+
+      (in ++ Stream.exec(cleanup))
+        .evalMap { elem =>
+          (selector(elem), queueMap.get).mapN { (key, queues) =>
+            queues.get(key).fold {
+              for {
+                newQ <- Queue.unbounded[F, Option[A]]
+                _    <- queueMap.modify(queues => (queues + (key -> newQ), queues))
+                _ <- newQ.offer(elem.some)
+              } yield (key -> Stream.fromQueueNoneTerminated(newQ, 100)).some
+            }(_.offer(elem.some).as(None))
+          }.flatten
+        }
+        .unNone
+        .onFinalize(cleanup)
+    }
+
+}

--- a/src/main/scala/com/example/stream/TransactionStream.scala
+++ b/src/main/scala/com/example/stream/TransactionStream.scala
@@ -27,10 +27,9 @@ final class TransactionStream[F[_]](
   processor: OrderProcessor[F]
 )(implicit F: Async[F], logger: Logger[F]) {
 
-  val stream: Stream[F, Unit] = processor.process(
-    Stream.fromQueueUnterminated(orders),
-    processUpdateWithCancellation
-  )
+  val stream: Stream[F, Unit] =
+    Stream.fromQueueUnterminated(orders)
+      .through(processor(processUpdateWithCancellation))
 
   // ensures the processing completes even if the fiber is canceled
   private def processUpdateWithCancellation(order: OrderRow): F[Unit] =
@@ -96,7 +95,7 @@ object TransactionStream {
         counter      <- Ref.of(0)
         queue        <- Queue.unbounded[F, OrderRow]
         stateManager <- StateManager.apply
-        processor    = OrderProcessor[F](strategy)
+        processor    = OrderProcessor(strategy)
       } yield new TransactionStream[F](
         operationTimer,
         queue,

--- a/src/main/scala/com/example/stream/TransactionStream.scala
+++ b/src/main/scala/com/example/stream/TransactionStream.scala
@@ -43,12 +43,11 @@ final class TransactionStream[F[_]](
     case Some(updatedOrder) =>
       PreparedQueries(session).use { queries =>
         for {
-          // Get current known order state
           state <- stateManager.getOrderState(updatedOrder.orderId, queries)
           _ <- OrderFsm.toTransaction(state, updatedOrder) match {
-            case Some(txn) => tryUpdate(updatedOrder, txn)(queries)
-            case None => ().pure[F]
-          }
+                 case Some(txn) => tryUpdate(updatedOrder, txn)(queries)
+                 case None      => ().pure[F]
+               }
         } yield ()
       }
     case None => ().pure[F]

--- a/src/main/scala/com/example/stream/TransactionStream.scala
+++ b/src/main/scala/com/example/stream/TransactionStream.scala
@@ -43,7 +43,7 @@ final class TransactionStream[F[_]](
       PreparedQueries(session).use { queries =>
         for {
           // Get current known order state
-          state <- stateManager.getOrderState(updatedOrder, queries)
+          state <- stateManager.getOrderState(updatedOrder.orderId, queries)
           _ <- OrderFsm.toTransaction(state, updatedOrder) match {
             case Some(transaction) => tryUpdate(updatedOrder, transaction)(queries)
             case None => ().pure[F]

--- a/src/main/scala/com/example/stream/TransactionStream.scala
+++ b/src/main/scala/com/example/stream/TransactionStream.scala
@@ -40,7 +40,7 @@ final class TransactionStream[F[_]](
           state <- stateManager.getOrderState(updatedOrder, queries)
           transaction = TransactionRow(state = state, updated = updatedOrder)
           // parameters for order update
-          params = state.filled *: state.orderId *: EmptyTuple
+          params = updatedOrder.filled *: updatedOrder.orderId *: EmptyTuple
           // update order with params
           _ <- queries.updateOrder.execute(params)
           // insert the transaction

--- a/src/main/scala/com/example/stream/TransactionStream.scala
+++ b/src/main/scala/com/example/stream/TransactionStream.scala
@@ -96,7 +96,7 @@ object TransactionStream {
         counter      <- Ref.of(0)
         queue        <- Queue.unbounded[F, OrderRow]
         stateManager <- StateManager.apply
-        processor    <- OrderProcessor.of(strategy)
+        processor    = OrderProcessor[F](strategy)
       } yield new TransactionStream[F](
         operationTimer,
         queue,

--- a/src/main/scala/com/example/stream/TransactionStream.scala
+++ b/src/main/scala/com/example/stream/TransactionStream.scala
@@ -2,13 +2,13 @@ package com.example.stream
 
 import cats.data.EitherT
 import cats.effect.implicits._
-import cats.effect.{Deferred, Ref, Resource}
+import cats.effect.{Ref, Resource}
 import cats.effect.kernel.Async
-import cats.effect.std.{MapRef, Queue}
+import cats.effect.std.Queue
 import fs2.Stream
 import org.typelevel.log4cats.Logger
 import cats.syntax.all._
-import com.example.model.{OrderId, OrderRow, TransactionRow}
+import com.example.model.{OrderRow, TransactionRow}
 import com.example.persistence.PreparedQueries
 import com.example.stream.OrderProcessor.ProcessingStrategy
 import org.typelevel.log4cats.syntax.LoggerInterpolator
@@ -84,7 +84,6 @@ final class TransactionStream[F[_]](
   def setSwitch(value: Boolean): F[Unit]                                          = stateManager.setSwitch(value)
   def addNewOrder(order: OrderRow, insert: PreparedCommand[F, OrderRow]): F[Unit] = stateManager.add(order, insert)
   // helper methods for testing
-
 }
 
 object TransactionStream {

--- a/src/main/scala/com/example/stream/TransactionStream.scala
+++ b/src/main/scala/com/example/stream/TransactionStream.scala
@@ -50,9 +50,10 @@ final class TransactionStream[F[_]](
 
   private def tryUpdate(order: OrderRow, txn: TransactionRow)(queries: PreparedQueries[F]): F[Unit] =
     for {
+
       _ <- queries.updateOrder.execute(order.filled *: order.orderId *: EmptyTuple)
       _ <- queries.insertTransaction.execute(txn)
-      _ <- performLongRunningOperation(txn).value.void.handleErrorWith(
+      _ <- performLongRunningOperation(txn).value.void.onError(
             logger.error(_)(s"Got error when performing long running F!")
           )
     } yield ()

--- a/src/test/scala/com/example/OrderFsmSpec.scala
+++ b/src/test/scala/com/example/OrderFsmSpec.scala
@@ -1,0 +1,87 @@
+package com.example
+
+import com.example.model.{OrderRow, TransactionRow}
+import com.example.stream.OrderFsm
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import java.util.UUID
+
+class OrderFsmSpec extends AnyFlatSpec with Matchers {
+
+  import OrderFsm._
+
+  // Helper function to create OrderRow instances
+  def createOrderRow(
+                      orderId: String,
+                      total: BigDecimal,
+                      filled: BigDecimal,
+                      createdAt: Instant = Instant.now(),
+                      updatedAt: Instant = Instant.now()
+                    ): OrderRow = OrderRow(orderId, "btc_eur", total, filled, createdAt, updatedAt)
+
+  // Helper function to create TransactionRow instances
+  def createTransactionRow(
+                            orderId: String,
+                            amount: BigDecimal,
+                            createdAt: Instant = Instant.now()
+                          ): TransactionRow = TransactionRow(UUID.randomUUID(), orderId, amount, createdAt)
+
+  "OrderFsm.check" should "return NonPositiveOrder when incoming filled is non-positive" in {
+    val existing = createOrderRow("1", 10, 5)
+
+    val incomingZero = createOrderRow("1", 10, 0)
+    OrderFsm.check(existing, incomingZero) shouldBe NonPositiveOrder
+
+    val incomingNegative = createOrderRow("1", 10, -1)
+    OrderFsm.check(existing, incomingNegative) shouldBe NonPositiveOrder
+  }
+
+  it should "return SmallerOrder when incoming filled is smaller than existing filled" in {
+    val existing = createOrderRow("1", 10, 5)
+    val incoming = createOrderRow("1", 10, 4)
+    OrderFsm.check(existing, incoming) shouldBe SmallerOrder
+  }
+
+  it should "return FilledOrder when existing filled equals total" in {
+    val existing = createOrderRow("1", 10, 10)
+    val incoming = createOrderRow("1", 10, 5)
+    OrderFsm.check(existing, incoming) shouldBe FilledOrder
+  }
+
+  it should "return ProcessOrder with updated order and new transaction when conditions are met" in {
+    val existing = createOrderRow("1", 10, 5)
+    val incoming = createOrderRow("1", 10, 7)
+
+    OrderFsm.check(existing, incoming) match {
+      case ProcessOrder(order, txn) =>
+        order shouldBe incoming
+        txn.orderId shouldBe existing.orderId
+        txn.amount shouldBe (incoming.filled - existing.filled)
+      case _ => fail("Expected ProcessOrder result")
+    }
+  }
+
+  it should "handle edge cases correctly" in {
+    // Incoming filled equals existing filled
+    val existing1 = createOrderRow("1", 10, 5)
+    val incoming1 = createOrderRow("1", 10, 5)
+    OrderFsm.check(existing1, incoming1) match {
+      case ProcessOrder(order, txn) =>
+        order shouldBe incoming1
+        txn.amount shouldBe 0
+      case _ => fail("Expected ProcessOrder result")
+    }
+
+    // Incoming filled equals total (but existing doesn't)
+    val existing2 = createOrderRow("2",  10, 8)
+    val incoming2 = createOrderRow("2", 10, 10)
+    OrderFsm.check(existing2, incoming2) match {
+      case ProcessOrder(order, txn) =>
+        order shouldBe incoming2
+        txn.amount shouldBe 2
+      case _ => fail("Expected ProcessOrder result")
+    }
+  }
+}

--- a/src/test/scala/com/example/OrderProcessorSpec.scala
+++ b/src/test/scala/com/example/OrderProcessorSpec.scala
@@ -1,0 +1,111 @@
+package com.example
+
+import cats.effect._
+import cats.effect.testing.scalatest.AsyncIOSpec
+import com.example.model.OrderRow
+import com.example.stream.OrderProcessor
+import fs2.Stream
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+import java.time.Instant
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class OrderProcessorSpec extends AsyncWordSpec with AsyncIOSpec with Matchers with OptionValues {
+
+  implicit override def executionContext: ExecutionContext = ExecutionContext.global
+
+  "OrderProcessor" should {
+
+    "process orders sequentially" in {
+      for {
+        processor <- OrderProcessor.of[IO](OrderProcessor.ProcessingStrategy.Sequential)
+        processedOrders <- Ref[IO].of(Vector.empty[OrderRow])
+        processOrder = (order: OrderRow) => IO.sleep(10.millis) *> processedOrders.update(_ :+ order)
+        orders = List(
+          OrderRow("1", "btc_eur", 100, 10, Instant.now, Instant.now),
+          OrderRow("2", "btc_eur", 100, 20, Instant.now, Instant.now),
+          OrderRow("1", "btc_eur", 100, 30, Instant.now, Instant.now),
+          OrderRow("3", "btc_eur", 100, 40, Instant.now, Instant.now),
+          OrderRow("2", "btc_eur", 100, 50, Instant.now, Instant.now)
+        )
+        _ <- processor.process(Stream.emits(orders), processOrder).compile.drain
+        result <- processedOrders.get
+      } yield {
+        result mustBe orders
+      }
+    }
+
+    "process orders concurrently but maintain order for same orderId" in {
+      for {
+        processor <- OrderProcessor.of[IO](OrderProcessor.ProcessingStrategy.Concurrent(3))
+        processedOrders <- Ref[IO].of(Vector.empty[OrderRow])
+        currentlyProcessing <- Ref[IO].of(Set.empty[String])
+        processOrder = (order: OrderRow) =>
+          for {
+            _ <- currentlyProcessing.update(_ + order.orderId)
+            _ <- currentlyProcessing.get
+            _ <- IO.sleep(50.millis) // Simulate some processing time
+            _ <- processedOrders.update(_ :+ order)
+            _ <- currentlyProcessing.update(_ - order.orderId)
+          } yield ()
+        orders = List(
+          OrderRow("1", "btc_eur", 100, 10, Instant.now, Instant.now),
+          OrderRow("2", "btc_eur", 100, 20, Instant.now, Instant.now),
+          OrderRow("1", "btc_eur", 100, 30, Instant.now, Instant.now),
+          OrderRow("3", "btc_eur", 100, 40, Instant.now, Instant.now),
+          OrderRow("2", "btc_eur", 100, 50, Instant.now, Instant.now)
+        )
+        _ <- processor.process(Stream.emits(orders), processOrder).compile.drain
+        result <- processedOrders.get
+        maxConcurrent <- currentlyProcessing.get.map(_.size)
+      } yield {
+        // Check that all orders were processed
+        result.size mustBe orders.size
+
+        // Check that orders with the same ID are processed in order
+        result.filter(_.orderId == "1").map(_.filled) mustBe Vector(10, 30)
+        result.filter(_.orderId == "2").map(_.filled) mustBe Vector(20, 50)
+
+        // Check that concurrent processing occurred
+        maxConcurrent mustBe >=(2)
+
+        // Check that the final result contains all orders
+        result.toSet mustBe orders.toSet
+      }
+    }
+
+    "handle a large number of orders efficiently" in {
+      val numOrders = 1000
+      val maxConcurrent = 10
+
+      for {
+        processor <- OrderProcessor.of[IO](OrderProcessor.ProcessingStrategy.Concurrent(maxConcurrent))
+        processedOrders <- Ref[IO].of(Vector.empty[OrderRow])
+        currentlyProcessing <- Ref[IO].of(Set.empty[String])
+        processOrder = (order: OrderRow) =>
+          for {
+            _ <- currentlyProcessing.update(_ + order.orderId)
+            _ <- IO.sleep(10.millis) // Simulate some processing time
+            _ <- processedOrders.update(_ :+ order)
+            _ <- currentlyProcessing.update(_ - order.orderId)
+          } yield ()
+        orders = (1 to numOrders).map(i =>
+                    OrderRow(s"order-${i % 100}", "btc_eur", 100, i, Instant.now, Instant.now)
+                  ).toList
+        start <- IO.monotonic
+        _ <- processor.process(Stream.emits(orders), processOrder).compile.drain
+        end <- IO.monotonic
+        result <- processedOrders.get
+        maxConcurrent <- currentlyProcessing.get.map(_.size)
+      } yield {
+        result.size mustBe numOrders
+        maxConcurrent mustBe <=(10)
+        (end - start).toMillis mustBe <(5.seconds.toMillis)
+      }
+    }
+  }
+}

--- a/src/test/scala/com/example/OrderProcessorSpec.scala
+++ b/src/test/scala/com/example/OrderProcessorSpec.scala
@@ -81,6 +81,49 @@ class OrderProcessorSpec extends AsyncWordSpec with AsyncIOSpec with Matchers wi
       }
     }
 
+    "should process concurrently to the configured limit regardless of unique events" in {
+      val processor = OrderProcessor.testConcurrent[IO](10)
+      val now = Instant.now
+      val orders = List(
+        OrderRow("1", "btc_eur", 100, 10, now, now),
+        OrderRow("2", "btc_eur", 100, 20, now, now),
+        OrderRow("1", "btc_eur", 100, 30, now, now),
+        OrderRow("2", "btc_eur", 100, 20, now, now),
+        OrderRow("3", "btc_eur", 100, 50, now, now),
+        OrderRow("1", "btc_eur", 100, 60, now, now),
+        OrderRow("5", "btc_eur", 100, 70, now, now),
+        OrderRow("4", "btc_eur", 100, 80, now, now),
+        OrderRow("2", "btc_eur", 100, 90, now, now)
+      )
+
+      for {
+        currentlyProcessing <- Ref.of[IO, Int](0)
+        maxConcurrencyRef <- Ref.of[IO, Int](0)
+        processedRef <- Ref[IO].of(Vector.empty[OrderRow])
+        processOrder = (order: OrderRow) =>
+          for {
+            _ <- currentlyProcessing.update(_ + 1)
+            current <- currentlyProcessing.get
+            _ <- maxConcurrencyRef.update(math.max(current, _))
+            _ <- IO.sleep(200.milliseconds) // Simulate some processing time
+            _ <- currentlyProcessing.update(_ - 1)
+            _ <- processedRef.update(_ :+ order)
+          } yield ()
+        _ <- Stream.emits(orders)
+          .covary[IO]
+          .metered(10.milliseconds)
+          .through(processor(processOrder))
+          .compile
+          .drain
+        _ <- IO.sleep(200.milliseconds)
+        processed <- processedRef.get
+        maxConcurrency <- maxConcurrencyRef.get
+      } yield {
+        processed.size shouldBe 9
+        maxConcurrency shouldBe 9
+      }
+    }
+
     "should process concurrently for different order ids equal to the configured limit" in {
       val processor = OrderProcessor.concurrent[IO](4)
       val now = Instant.now

--- a/src/test/scala/com/example/TransactionStreamSpec.scala
+++ b/src/test/scala/com/example/TransactionStreamSpec.scala
@@ -95,6 +95,7 @@ class TransactionStreamSpec extends FixtureAsyncWordSpec with BaseIOSpec with Op
         }
       }
 
+      // what is the criteria for sameness ?
       "T3: process a case where the same message is delivered twice" in { fxt =>
         val ts = Instant.now
         val order = OrderRow(

--- a/src/test/scala/com/example/TransactionStreamSpec.scala
+++ b/src/test/scala/com/example/TransactionStreamSpec.scala
@@ -22,7 +22,7 @@ class TransactionStreamSpec extends FixtureAsyncWordSpec with BaseIOSpec with Op
 
     "processing orders" must {
 
-      "T1: process one updates resulting in one transaction" in { fxt =>
+      "T1: process one update resulting in one transaction" in { fxt =>
         val ts = Instant.now
         val order = OrderRow(
           orderId = "example_id",


### PR DESCRIPTION
- Created an `OrderFsm` class which manages creation of records (not a proper FSM, can be improved)
- Defined a transactional `tryUpdate` which performs db writes if the long running effect succeeds
- Handled fiber cancellation on `processUpdate` so that current items are always processed
- Defined `OrderProcessor` which based on `ProcessingStrategy` handles the order stream processing

Todo:
 - Validation can be improved; left the "naive" implementation as most of this can be handled with let's say `refined`
 - Didn't fix the logic to satisfy T8. Didn't know how to trigger it since the stream is not complied. Tried:
 ```scala
 def processRemaining: F[Unit] = {
   def loop: F[Unit] = orders.tryTake.flatMap {
     case Some(order) => processUpdate(order); loop
     case None => ().pure[F]
   }
   
   loop
}
```
but don't know what can trigger it.
 - The code base can be restructured into smaller units and logic can be generalized.